### PR TITLE
Fix invisible highlight in integrated terminal

### DIFF
--- a/themes/Better Solarized Light-color-theme.json
+++ b/themes/Better Solarized Light-color-theme.json
@@ -1336,6 +1336,7 @@
     "terminal.ansiBrightMagenta": "#6c71c4",
     "terminal.ansiBrightCyan": "#93a1a1",
     "terminal.ansiBrightWhite": "#eee8d5",
+    "terminal.selectionBackground": "#073642",
     // Interactive Playground
     "walkThrough.embeddedEditorBackground": "#00000014"
   }

--- a/themes/Better Solarized Light-color-theme.json
+++ b/themes/Better Solarized Light-color-theme.json
@@ -1336,7 +1336,7 @@
     "terminal.ansiBrightMagenta": "#6c71c4",
     "terminal.ansiBrightCyan": "#93a1a1",
     "terminal.ansiBrightWhite": "#eee8d5",
-    "terminal.selectionBackground": "#073642",
+    "terminal.selectionBackground": "#DDD6C1",
     // Interactive Playground
     "walkThrough.embeddedEditorBackground": "#00000014"
   }


### PR DESCRIPTION
The highlight color in the integrated terminal when using the light theme is practically invisible.

This just uses the `ansiBlack` equivalent 

![image](https://github.com/edheltzel/vscode-better-solarized/assets/24867393/b3485bf4-4272-4223-8a32-12b3b914d155)
